### PR TITLE
Update que-scheduler migration to version 6

### DIFF
--- a/_drafts/que-scheduler.md
+++ b/_drafts/que-scheduler.md
@@ -22,7 +22,7 @@ Install and apply the setup migration to get started:
 gem 'que-scheduler'
 
 # In a migration...
-Que::Scheduler::Migrations.migrate!(version: 5)
+Que::Scheduler::Migrations.migrate!(version: 6)
 ```
 
 ## Built on the que bedrock


### PR DESCRIPTION
There has been a major release which came with a [new migration level](https://github.com/hlascelles/que-scheduler/pull/224/files#diff-26fbd2f9313514a37742f7d2d07c4a8c6f81ef21f6bd02856183416dcc11417cR1) for the que-scheduler gem.

Best update it before it goes public!